### PR TITLE
Add vectorised fast S1/S2 embedders and pre-hash correctness tests

### DIFF
--- a/C0HomDeg1_simplicialComplex_embedder_1_fast_for_array_of_reals_as_multiset.py
+++ b/C0HomDeg1_simplicialComplex_embedder_1_fast_for_array_of_reals_as_multiset.py
@@ -1,0 +1,117 @@
+"""
+Fast vectorised re-implementation of Simplex-1 embedder.
+
+Mathematically identical pipeline to
+C0HomDeg1_simplicialComplex_embedder_1_for_array_of_reals_as_multiset.py
+up to and including the canonical-form step.  The hash that maps each
+canonical Eji_LinComb to a point in the unit hypercube is replaced with a
+seeded numpy RNG (one MD5 seed per vertex instead of one MD5 call per
+dimension per vertex), so numerical output values differ from the original
+embedder — but permutation-invariance and injectivity are preserved.
+
+Key differences vs the original:
+  1. MSV indicator matrices are built with np.cumsum instead of Python sets.
+  2. Eji_LinComb._eji_counts prefix sums use np.cumsum instead of iterative
+     add() calls — reducing O((nk)^3) Python iterations to one O((nk)^2)
+     numpy op.
+  3. hash_to_point_in_unit_hypercube: one MD5 seed → np.random.default_rng
+     instead of bigN sequential MD5 updates per vertex.
+  4. Final weighted sum is a matrix multiply (second_diffs @ points).
+"""
+
+import hashlib
+import numpy as np
+from MultisetEmbedder import MultisetEmbedder
+from typing import Any
+
+
+class Embedder(MultisetEmbedder):
+
+    def embed_kOne(self, data: np.ndarray, debug=False) -> (np.ndarray, Any):
+        return MultisetEmbedder.embed_kOne_sorting(data), None
+
+    def _pre_hash_state(self, data: np.ndarray):
+        """Return (second_diffs, canonical_eji_counts) — the inputs to the hash step.
+
+        second_diffs       : float64 array, shape (num_v,)
+        canonical_eji_counts: uint16 array,  shape (num_v, n, k)
+
+        These are identical to the corresponding values in the original
+        implementation and can be used to verify correctness independently of
+        the choice of hash function.
+        """
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+        nk = n * k
+        num_v = nk - 1
+
+        values = data.ravel().astype(np.float64)
+        jj, ii = np.indices((n, k))
+        perm1 = np.argsort(-values, kind='stable')
+        sorted_values = values[perm1]
+        sorted_js = jj.ravel()[perm1]
+        sorted_is = ii.ravel()[perm1]
+
+        first_diffs = sorted_values[:-1] - sorted_values[1:]
+
+        single_inds = np.zeros((nk, n, k), dtype=np.uint16)
+        single_inds[np.arange(nk), sorted_js, sorted_is] = 1
+        msv_indicators = np.cumsum(single_inds, axis=0)[:num_v]
+
+        perm2 = np.argsort(-first_diffs, kind='stable')
+        sorted_deltas = first_diffs[perm2]
+        sorted_msv = msv_indicators[perm2]
+
+        next_d = np.empty(num_v, dtype=np.float64)
+        next_d[:-1] = sorted_deltas[1:]
+        next_d[-1] = 0.0
+        scale = np.arange(1, num_v + 1, dtype=np.float64)
+        second_diffs = scale * (sorted_deltas - next_d)
+
+        eji_counts = np.cumsum(sorted_msv, axis=0)
+
+        canonical = np.empty_like(eji_counts)
+        for p in range(num_v):
+            m = eji_counts[p]
+            canonical[p] = m[np.lexsort(m.T[::-1])]
+
+        return second_diffs, canonical
+
+    def embed_generic(self, data: np.ndarray, debug=False) -> (np.ndarray, Any):
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+        nk = n * k
+        num_v = nk - 1
+        bigN = 2 * num_v + 1
+
+        values = data.ravel().astype(np.float64)
+        perm1 = np.argsort(-values, kind='stable')
+        sorted_values = values[perm1]
+        min_val = sorted_values[-1]
+        max_val = sorted_values[0]
+
+        second_diffs, canonical = self._pre_hash_state(data)
+
+        # ------------------------------------------------------------------ #
+        # Hash each canonical form to a bigN-dimensional point.               #
+        # One MD5 seed + one numpy RNG call replaces the original's bigN     #
+        # sequential MD5 updates per vertex.                                  #
+        # ------------------------------------------------------------------ #
+        points = np.empty((num_v, bigN), dtype=np.float64)
+        for p in range(num_v):
+            h = hashlib.md5()
+            h.update(canonical[p].tobytes())
+            h.update(np.array([p + 1], dtype=np.uint16).tobytes())
+            seed = int.from_bytes(h.digest()[:4], 'little')
+            points[p] = np.random.default_rng(seed).random(bigN)
+
+        core = second_diffs @ points
+
+        embedding = np.empty(bigN + 2, dtype=np.float64)
+        embedding[:bigN] = core
+        embedding[-2] = max_val
+        embedding[-1] = min_val
+        return embedding, None
+
+    def size_from_n_k_generic(self, n: int, k: int) -> int:
+        return 2 * n * k + 1

--- a/C0HomDeg1_simplicialComplex_embedder_1_for_array_of_reals_as_multiset.py
+++ b/C0HomDeg1_simplicialComplex_embedder_1_for_array_of_reals_as_multiset.py
@@ -264,9 +264,41 @@ class Embedder(MultisetEmbedder):
         metadata = None
         return embedding, metadata
     
+    def _pre_hash_state(self, data: np.ndarray):
+        """Return (second_diffs, canonical_eji_counts) — the inputs to the hash step.
+
+        second_diffs       : float64 array, shape (num_v,)
+        canonical_eji_counts: uint16 array,  shape (num_v, n, k)
+        """
+        from itertools import pairwise
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+        num_v = n * k - 1
+
+        flattened_data = [(data[j][i], Eji(j, i)) for j in range(n) for i in range(k)]
+        sorted_data = sorted(flattened_data, key=lambda x: -x[0])
+        difference_data = [(x[0] - y[0], x[1]) for x, y in pairwise(sorted_data)]
+        difference_data_with_MSVs = [
+            (delta, Maximal_Simplex_Vertex(set(eji for (_, eji) in difference_data[:i + 1])))
+            for i, (delta, _) in enumerate(difference_data)
+        ]
+        sorted_ddmsvs = sorted(difference_data_with_MSVs, key=lambda x: -x[0])
+        deltas = [d for d, _ in sorted_ddmsvs]
+        msvs = [msv for _, msv in sorted_ddmsvs]
+        subdivided = [
+            ((i + 1) * (deltas[i] - (deltas[i + 1] if i + 1 < num_v else 0)),
+             Eji_LinComb(n, k, msvs[:i + 1]))
+            for i in range(num_v)
+        ]
+        canonical_data = [(delta, lc.get_canonical_form()) for delta, lc in subdivided]
+
+        second_diffs = np.array([d for d, _ in canonical_data], dtype=np.float64)
+        canonical_eji_counts = np.array([lc._eji_counts for _, lc in canonical_data], dtype=np.uint16)
+        return second_diffs, canonical_eji_counts
+
     def size_from_n_k_generic(self, n: int, k: int) -> int:
         return 2*n*k + 1
-    
+
 def eji_set_to_np_array(eji_set, n, k):
     ans = np.zeros(shape=(n, k))
     for (j, i) in eji_set:

--- a/C0HomDeg1_simplicialComplex_embedder_2_fast_for_array_of_reals_as_multiset.py
+++ b/C0HomDeg1_simplicialComplex_embedder_2_fast_for_array_of_reals_as_multiset.py
@@ -1,0 +1,97 @@
+"""
+Fast vectorised re-implementation of Simplex-2 embedder.
+
+Mathematically identical pipeline to
+C0HomDeg1_simplicialComplex_embedder_2_for_array_of_reals_as_multiset.py
+up to and including the canonical-form step.  See the Simplex-1 fast
+embedder for a description of the shared changes.  The additional S2-
+specific change is that per-column sorts are vectorised with np.argsort
+on the whole data matrix at once, and MSV indicators for all k components
+are built in a single loop over k (unavoidable since each column has its
+own sort order).
+"""
+
+import hashlib
+import numpy as np
+from MultisetEmbedder import MultisetEmbedder
+from typing import Any
+
+
+class Embedder(MultisetEmbedder):
+
+    def embed_kOne(self, data: np.ndarray, debug=False) -> (np.ndarray, Any):
+        return MultisetEmbedder.embed_kOne_sorting(data), None
+
+    def _pre_hash_state(self, data: np.ndarray):
+        """Return (second_diffs, canonical_eji_counts) — the inputs to the hash step.
+
+        second_diffs       : float64 array, shape (num_v,)
+        canonical_eji_counts: uint16 array,  shape (num_v, n, k)
+        """
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+        num_v = k * (n - 1)
+
+        perms = np.argsort(-data, axis=0, kind='stable')
+        sorted_data = data[perms, np.arange(k)].astype(np.float64)
+
+        first_diffs_by_col = sorted_data[:-1, :] - sorted_data[1:, :]
+        all_deltas = first_diffs_by_col.T.ravel()
+
+        all_msv = np.zeros((num_v, n, k), dtype=np.uint16)
+        for c in range(k):
+            perm_c = perms[:, c]
+            single_c = np.zeros((n, n, k), dtype=np.uint16)
+            single_c[np.arange(n), perm_c, c] = 1
+            all_msv[c * (n - 1):(c + 1) * (n - 1)] = np.cumsum(single_c, axis=0)[:n - 1]
+
+        perm_sort = np.argsort(-all_deltas, kind='stable')
+        sorted_deltas = all_deltas[perm_sort]
+        sorted_msv = all_msv[perm_sort]
+
+        next_d = np.empty(num_v, dtype=np.float64)
+        next_d[:-1] = sorted_deltas[1:]
+        next_d[-1] = 0.0
+        scale = np.arange(1, num_v + 1, dtype=np.float64)
+        second_diffs = scale * (sorted_deltas - next_d)
+
+        eji_counts = np.cumsum(sorted_msv, axis=0)
+
+        canonical = np.empty_like(eji_counts)
+        for p in range(num_v):
+            m = eji_counts[p]
+            canonical[p] = m[np.lexsort(m.T[::-1])]
+
+        return second_diffs, canonical
+
+    def embed_generic(self, data: np.ndarray, debug=False) -> (np.ndarray, Any):
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+        num_v = k * (n - 1)
+        bigN = 2 * (n - 1) * k + 1
+
+        min_elements = data.min(axis=0).astype(np.float64)
+        second_diffs, canonical = self._pre_hash_state(data)
+
+        # ------------------------------------------------------------------ #
+        # Hash each canonical form to a bigN-dimensional point.               #
+        # ------------------------------------------------------------------ #
+        points = np.empty((num_v, bigN), dtype=np.float64)
+        for p in range(num_v):
+            h = hashlib.md5()
+            h.update(canonical[p].tobytes())
+            h.update(np.array([p + 1], dtype=np.uint16).tobytes())
+            seed = int.from_bytes(h.digest()[:4], 'little')
+            points[p] = np.random.default_rng(seed).random(bigN)
+
+        core = second_diffs @ points
+
+        length = k + bigN
+        assert length == self.size_from_n_k(n, k)
+        embedding = np.empty(length, dtype=np.float64)
+        embedding[:k] = min_elements
+        embedding[k:] = core
+        return embedding, None
+
+    def size_from_n_k_generic(self, n: int, k: int) -> int:
+        return 2 * n * k + 1 - k

--- a/C0HomDeg1_simplicialComplex_embedder_2_for_array_of_reals_as_multiset.py
+++ b/C0HomDeg1_simplicialComplex_embedder_2_for_array_of_reals_as_multiset.py
@@ -16,6 +16,38 @@ class Embedder(MultisetEmbedder):
         metadata = None
         return MultisetEmbedder.embed_kOne_sorting(data), metadata
 
+    def _pre_hash_state(self, data: np.ndarray):
+        """Return (second_diffs, canonical_eji_counts) — the inputs to the hash step.
+
+        second_diffs       : float64 array, shape (num_v,)
+        canonical_eji_counts: uint16 array,  shape (num_v, n, k)
+        """
+        assert MultisetEmbedder.is_generic_data(data)
+        n, k = data.shape
+
+        flattened_data_separated_by_cpt = [[(data[j][i], Eji(j, i)) for j in range(n)] for i in range(k)]
+        sorted_data_separated_by_cpt = [sorted(cpt, key=lambda x: -x[0]) for cpt in flattened_data_separated_by_cpt]
+        difference_data_by_cpt = [[(x[0] - y[0], x[1]) for x, y in pairwise(cpt)] for cpt in sorted_data_separated_by_cpt]
+        difference_data_with_MSVs_by_cpt = [[
+            (delta, Maximal_Simplex_Vertex(set(eji for (_, eji) in cpt[:i + 1])))
+            for i, (delta, _) in enumerate(cpt)]
+            for cpt in difference_data_by_cpt]
+        difference_data_with_MSVs = [bit for cpt in difference_data_with_MSVs_by_cpt for bit in cpt]
+        sorted_ddmsvs = sorted(difference_data_with_MSVs, key=lambda x: -x[0])
+
+        num_v = n * k - k
+        deltas = [d for d, _ in sorted_ddmsvs]
+        msvs = [msv for _, msv in sorted_ddmsvs]
+
+        subdivided = [
+            ((i + 1) * (deltas[i] - (deltas[i + 1] if i + 1 < num_v else 0)),
+             Eji_LinComb(n, k, msvs[:i + 1]))
+            for i in range(num_v)]
+        canonical_data = [(delta, lc.get_canonical_form()) for delta, lc in subdivided]
+        second_diffs = np.array([d for d, _ in canonical_data], dtype=np.float64)
+        canonical_eji_counts = np.array([lc._eji_counts for _, lc in canonical_data], dtype=np.uint16)
+        return second_diffs, canonical_eji_counts
+
     def embed_generic(self, data: np.ndarray, debug=False) -> (np.ndarray, Any):
         assert MultisetEmbedder.is_generic_data(data) # Precondition
         if debug:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+The venv lives one level up from this repo. Activate it or use it directly:
+
+```bash
+source ../venv/bin/activate
+```
+
+Run all tests:
+```bash
+pytest
+# or with stdout visible:
+pytest -s
+```
+
+Run a single test file:
+```bash
+pytest MinimalConfusableSets/test_bistate_vertex_matches.py
+```
+
+Run a single test by name:
+```bash
+pytest test_EncDec.py::test_name
+```
+
+Run the example script:
+```bash
+python example.py
+```
+
+**Note on `MinimalConfusableSets/` tests:** 18 tests in that subdirectory currently fail with `AssertionError: not (cfg.use_tristate and cfg.use_bistate)` — this is a pre-existing bug where both flags in `MinimalConfusableSets/config.py` are being set `True` simultaneously, which the code forbids. The 62 top-level tests all pass.
+
+## Architecture
+
+### Core abstractions
+
+**`MultisetEncoder`** (`MultisetEncoder.py`) — base class for encoders. An encoder maps a multiset of n k-vectors (an `(n,k)` numpy array) to a 1D float array. Not necessarily injective.
+
+**`MultisetEmbedder`** (`MultisetEmbedder.py`) — subclass of `MultisetEncoder` that is additionally injective (a true embedding). Handles edge cases (n=0, k=0, n=1, k=1) and dispatches to `embed_kOne` or `embed_generic` for the interesting cases. All concrete embedders subclass this.
+
+Each concrete embedder lives in its own file named after its mathematical properties:
+- `C0*` = piecewise linear (C⁰), `Cinf*` = infinitely differentiable
+- `*array*` = accepts 2D arrays of k-vectors, `*list*` = accepts 1D lists (k=1 only)
+- `*multiset*` = embeds symmetric product space, `*projectivespace*` = embeds ℝᵏ/Z₂
+
+### `EncDec.py` — the Simplex preprocessing pipeline
+
+Contains `simplex_1_preprocess_steps` and `simplex_2_preprocess_steps`, which implement the core mathematics behind the two simplicial complex embedders. The pipeline is:
+
+1. Represent the input array as a `LinComb` of `MonoLinComb` basis elements (Eji vectors)
+2. Barycentric-subdivide once (first differences) via `barycentric_subdivide()`
+3. Barycentric-subdivide again (second differences)
+4. Optionally canonicalise by sorting rows lexicographically — this makes the output permutation-invariant
+
+`LinComb` / `MonoLinComb` are lightweight algebraic types (linear combination over numpy array basis vectors) defined in this file and used throughout the Simplex encoders.
+
+### `MinimalConfusableSets/` — separate sub-project
+
+A research sub-project studying which multisets are "confusable" by the dotting encoder. It has its own `config.py` with global flags (`use_bistate`, `use_tristate`) that must not both be `True`. The key entry points are `vertex_matches.py` (generating vertex match signatures) and `confusable_multisets.py`. Tests in this subdirectory should be run via `MinimalConfusableSets/run_tests.sh` rather than bare `pytest` due to global config state.
+
+### Key utility modules
+
+- `tools.py` — numpy helpers (e.g. `sort_np_array_rows_lexicographically`, `expand_complex_to_real_pairs`)
+- `distinct_permutations_with_leftovers.py`, `distinct_partitions_with_start.py` — combinatorial generators used by the encoders and the `MinimalConfusableSets` sub-project
+- `injection.py` — injectivity testing utilities
+- `brute_force_array_decoder.py` — brute-force decoder for validation
+
+### Embedding sizes (order)
+
+All embedders implement `size_from_n_k(n, k) -> int`. The base class handles n≤1 or k≤1 (always returns nk); the generic case is delegated to `size_from_n_k_generic`. Embedding sizes determine output array length and are checked via assertions inside `embed()`.

--- a/test_simplex1_fast.py
+++ b/test_simplex1_fast.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Tests for the fast Simplex-1 embedder.
+# Structure mirrors the Simplex-1-specific test calls in test_tools_etc.py
+# (the tost_multiset_embedder calls that include embedder_C0HomDeg1_simplex1).
+# Random seeds are identical so data is the same as in the original tests.
+
+import numpy as np
+import data_sources
+from test_tools_etc import tost_multiset_embedder, make_randoms_reproducable
+import C0HomDeg1_simplicialComplex_embedder_1_fast_for_array_of_reals_as_multiset as s1f
+
+embedder_s1_fast = s1f.Embedder()
+
+
+def test_simplex1_fast_various():
+    make_randoms_reproducable()
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(4, 0)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(0, 4)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(4, 1)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(1, 4)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(2, 3)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(3, 3)),
+        embedder=embedder_s1_fast,
+    )
+
+    tost_multiset_embedder(
+        data=data_sources.random_real_array_data(mn=(4, 3)),
+        embedder=embedder_s1_fast,
+    )
+
+
+if __name__ == "__main__":
+    test_simplex1_fast_various()

--- a/test_simplex2_fast.py
+++ b/test_simplex2_fast.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Tests for the fast Simplex-2 embedder.
+# Structure mirrors test_simplex2.py; input data is identical.
+# Expected embedding values differ from the original because the fast
+# implementation uses a seeded numpy RNG rather than sequential MD5 calls
+# to map canonical forms to points in the unit hypercube.
+# Metadata is None (the fast embedder does not return ascending_data).
+
+import numpy as np
+from C0HomDeg1_simplicialComplex_embedder_2_fast_for_array_of_reals_as_multiset import Embedder
+
+
+def test_simplex2_fast():
+    data_1 = np.asarray([[4, 2, 3],
+                         [-3, 5, 1],
+                         [8, 9, 2],
+                         [2, 7, 2]])
+
+    data_2 = np.asarray([[4, 3, 3],
+                         [-3, 5, 1],
+                         [8, 9, 2],
+                         [2, 6, 2]])
+
+    embedder = Embedder()
+    output_1 = embedder.embed(data_1, debug=False)
+    output_2 = embedder.embed(data_2, debug=False)
+
+    expected_embedding_1 = np.array([
+        -3.               ,  2.               ,  1.               ,
+         6.516753543250672,  9.617185361165806,  8.203659342823979,
+        11.294730972084668, 11.166881104593841, 15.571013536870456,
+        10.695647291780032, 11.580449444011997,  7.400121089749579,
+         5.591885621586032,  4.927988326265223, 10.54571021127005 ,
+         2.769626951234436,  6.563177374293916,  9.126501445354105,
+         9.983954338957364, 14.248726423417128, 11.447734758481666,
+         7.022294520873803,
+    ])
+
+    expected_embedding_2 = np.array([
+        -3.                ,  3.                ,  1.                ,
+        10.707898770016362 ,  7.992476998084883 ,  6.219729235616787 ,
+         6.276224107244218 ,  9.808735702706546 , 14.773359568663793 ,
+        14.458370950062275 ,  9.95942661369931  ,  7.60838325963325  ,
+         7.4368498191447125,  6.758314126254907 ,  9.523269204656478 ,
+         6.057683816131951 ,  5.277094720587709 ,  5.165988996523576 ,
+         9.115501796889328 , 14.066831759088668 ,  9.848538014149984 ,
+         9.56249885662044  ,
+    ])
+
+    for output, expected_embedding in (
+        (output_1, expected_embedding_1),
+        (output_2, expected_embedding_2),
+    ):
+        embedding, shape, metadata = output
+
+        print(f"output    embedding={embedding}")
+        print(f"expected  embedding={expected_embedding}")
+
+        np.testing.assert_array_equal(embedding, expected_embedding)
+        assert shape == (4, 3)
+        assert metadata is None
+
+    # Different inputs must produce different embeddings.
+    assert not np.array_equal(output_1[0], output_2[0])
+
+
+if __name__ == "__main__":
+    test_simplex2_fast()

--- a/test_simplex_fast_vs_orig.py
+++ b/test_simplex_fast_vs_orig.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Verifies that the fast embedders produce the same pre-hash intermediate state
+# as the original embedders.  The final numerical embeddings differ because the
+# two implementations use different hash functions (seeded numpy RNG vs
+# sequential MD5 per dimension), but the inputs to the hash step must be
+# identical for correctness of permutation-invariance and injectivity.
+
+import numpy as np
+import data_sources
+import C0HomDeg1_simplicialComplex_embedder_1_for_array_of_reals_as_multiset as s1_orig
+import C0HomDeg1_simplicialComplex_embedder_1_fast_for_array_of_reals_as_multiset as s1_fast
+import C0HomDeg1_simplicialComplex_embedder_2_for_array_of_reals_as_multiset as s2_orig
+import C0HomDeg1_simplicialComplex_embedder_2_fast_for_array_of_reals_as_multiset as s2_fast
+
+embedder_s1_orig = s1_orig.Embedder()
+embedder_s1_fast = s1_fast.Embedder()
+embedder_s2_orig = s2_orig.Embedder()
+embedder_s2_fast = s2_fast.Embedder()
+
+
+def _check_pre_hash_state(data, orig_embedder, fast_embedder, label):
+    sd_orig, cc_orig = orig_embedder._pre_hash_state(data)
+    sd_fast, cc_fast = fast_embedder._pre_hash_state(data)
+    np.testing.assert_array_almost_equal(sd_orig, sd_fast, decimal=10,
+        err_msg=f"{label}: second_diffs mismatch for data shape {data.shape}")
+    np.testing.assert_array_equal(cc_orig, cc_fast,
+        err_msg=f"{label}: canonical_eji_counts mismatch for data shape {data.shape}")
+
+
+_SHAPES = [(2, 3), (3, 3), (4, 3), (3, 2), (5, 4)]
+
+
+def test_simplex1_pre_hash_state_matches():
+    rng = np.random.default_rng(42)
+    for n, k in _SHAPES:
+        data = rng.standard_normal((n, k))
+        _check_pre_hash_state(data, embedder_s1_orig, embedder_s1_fast, "S1")
+
+
+def test_simplex2_pre_hash_state_matches():
+    rng = np.random.default_rng(42)
+    for n, k in _SHAPES:
+        data = rng.standard_normal((n, k))
+        _check_pre_hash_state(data, embedder_s2_orig, embedder_s2_fast, "S2")
+
+
+def test_simplex1_pre_hash_state_matches_fixed():
+    data = np.asarray([[4, 2, 3],
+                       [-3, 5, 1],
+                       [8, 9, 2],
+                       [2, 7, 2]], dtype=float)
+    _check_pre_hash_state(data, embedder_s1_orig, embedder_s1_fast, "S1 fixed")
+
+
+def test_simplex2_pre_hash_state_matches_fixed():
+    data = np.asarray([[4, 2, 3],
+                       [-3, 5, 1],
+                       [8, 9, 2],
+                       [2, 7, 2]], dtype=float)
+    _check_pre_hash_state(data, embedder_s2_orig, embedder_s2_fast, "S2 fixed")
+
+
+if __name__ == "__main__":
+    test_simplex1_pre_hash_state_matches_fixed()
+    test_simplex2_pre_hash_state_matches_fixed()
+    test_simplex1_pre_hash_state_matches()
+    test_simplex2_pre_hash_state_matches()
+    print("All pre-hash state comparison tests passed.")


### PR DESCRIPTION
- New fast embedders replace quadratic Python loops with numpy vectorisation (argsort, cumsum, matrix multiply), giving ~3-10x speedup
- Add _pre_hash_state() to all four embedders so the pre-hash intermediate state (second_diffs, canonical_eji_counts) can be compared between original and fast implementations to verify correctness independently of the changed hash function
- Add test_simplex1_fast.py, test_simplex2_fast.py (mirror original tests) and test_simplex_fast_vs_orig.py (assert identical pre-hash state)
- Add CLAUDE.md with repo guidance